### PR TITLE
获取参数的方式错误

### DIFF
--- a/sandbox-debug-module/src/main/java/com/alibaba/jvm/sandbox/module/debug/DebugModule.java
+++ b/sandbox-debug-module/src/main/java/com/alibaba/jvm/sandbox/module/debug/DebugModule.java
@@ -170,7 +170,7 @@ public class DebugModule implements Module {
 
         int expand;
         try {
-            expand = Integer.getInteger(req.getParameter("expand"));
+            expand = Integer.parseInt(req.getParameter("expand"));
         } catch (Throwable cause) {
             expand = 1;
         }


### PR DESCRIPTION
Integer.getInteger  是从 System.getProperty  中获取值，该方式没有获得到get的参数