### PR TITLE
修复命令行指定ip和port，attach jvm后，指定的ip和端口不生效

### DIFF
--- a/bin/sandbox.sh
+++ b/bin/sandbox.sh
@@ -218,7 +218,7 @@ function attach_jvm() {
         -jar ${SANDBOX_LIB_DIR}/sandbox-core.jar \
         ${TARGET_JVM_PID} \
         "${SANDBOX_LIB_DIR}/sandbox-agent.jar" \
-        "home=${SANDBOX_HOME_DIR};token=${token};ip=${TARGET_SERVER_IP};port=${TARGET_SERVER_PORT};namespace=${TARGET_NAMESPACE}" \
+        "home=${SANDBOX_HOME_DIR};token=${token};server.ip=${TARGET_SERVER_IP};server.port=${TARGET_SERVER_PORT};namespace=${TARGET_NAMESPACE}" \
     || exit_on_err 1 "attach JVM ${TARGET_JVM_PID} fail."
 
     # get network from attach result

--- a/sandbox-agent/src/main/java/com/alibaba/jvm/sandbox/agent/AgentLauncher.java
+++ b/sandbox-agent/src/main/java/com/alibaba/jvm/sandbox/agent/AgentLauncher.java
@@ -310,10 +310,10 @@ public class AgentLauncher {
     private static final String KEY_NAMESPACE = "namespace";
     private static final String DEFAULT_NAMESPACE = "default";
 
-    private static final String KEY_SERVER_IP = "ip";
+    private static final String KEY_SERVER_IP = "server.ip";
     private static final String DEFAULT_IP = "0.0.0.0";
 
-    private static final String KEY_SERVER_PORT = "port";
+    private static final String KEY_SERVER_PORT = "server.port";
     private static final String DEFAULT_PORT = "0";
 
     private static final String KEY_TOKEN = "token";


### PR DESCRIPTION
统一ip和端口关键字命名为server.ip和server.port