### PR TITLE
排除代理类的增强

### DIFF
--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/matcher/UnsupportedMatcher.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/matcher/UnsupportedMatcher.java
@@ -36,7 +36,9 @@ public class UnsupportedMatcher implements Matcher {
                 classStructure.getJavaClassName(),
                 "$$Lambda$",
                 "$$FastClassBySpringCGLIB$$",
-                "$$EnhancerBySpringCGLIB$$"
+                "$$EnhancerBySpringCGLIB$$",
+                "$$EnhancerByCGLIB$$",
+                "$$FastClassByCGLIB$$"
         );
     }
 


### PR DESCRIPTION
修改UnsupportedMatcher类排除"$$EnhancerByCGLIB$$","$$FastClassByCGLIB$$"两种类的增强，否则增强后的构造函数调用报错java.lang.VerifyError