### PR TITLE
fix error that can't find java home

### DIFF
--- a/bin/sandbox.sh
+++ b/bin/sandbox.sh
@@ -205,6 +205,9 @@ reset_for_env()
             |grep ${TARGET_JVM_PID}\
             |grep java\
             |awk '{print $11}'\
+            |xargs which\
+            |xargs ls -l\
+            |awk '{if($1~/^l/){print $11}else{print $9}}'\
             |xargs ls -l\
             |awk '{if($1~/^l/){print $11}else{print $9}}'\
             |sed 's/\/bin\/java//g'\

--- a/bin/sandbox.sh
+++ b/bin/sandbox.sh
@@ -201,11 +201,9 @@ reset_for_env()
     # use the target JVM for SANDBOX_JAVA_HOME
     [[ -z ${SANDBOX_JAVA_HOME} ]] \
         && SANDBOX_JAVA_HOME="$(\
-            ps aux\
-            |grep ${TARGET_JVM_PID}\
-            |grep java\
-            |awk '{print $11}'\
-            |xargs which\
+            lsof -p ${TARGET_JVM_PID}\
+            |grep "/bin/java"\
+            |awk '{print $9}'\
             |xargs ls -l\
             |awk '{if($1~/^l/){print $11}else{print $9}}'\
             |xargs ls -l\


### PR DESCRIPTION
sandbox.sh can't find java home for the following situation :

```bash
> ps -ef |grep java
root     59531     1  0 15:17 pts/1    00:00:10 java -jar target/framework-test.jar

> java -version
openjdk version "1.8.0_40"

> which java
/usr/bin/java

> ls -l /usr/bin/java
lrwxrwxrwx 1 root root 22 Jun  4 11:37 /usr/bin/java -> /etc/alternatives/java

> which /etc/alternatives/java
/etc/alternatives/java

> ls -l /etc/alternatives/java
lrwxrwxrwx 1 root root 40 Jun 10 15:23 /etc/alternatives/java -> /usr/local/java/java-se-8u40-ri/bin/java
```
