### PR TITLE
Add process selector of current running jvm process if -p port is missing

### DIFF
--- a/bin/jps.sh
+++ b/bin/jps.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# jps.sh version 1.0.2
+
+# there might be multiple java processes, e.g. log-agent
+JPS_CMDS=($(ps aux | grep java | grep -v 'grep java' | awk '{print $11}' | sed -n 's/java$/jps/p'))
+
+# find the first executable jps command
+JPS_CMD=""
+for jps in ${JPS_CMDS[@]}; do
+  if [[ -x $jps ]]; then
+     JPS_CMD=$jps
+     break
+  fi
+done
+
+if [[ "$JPS_CMD" == "" ]]; then
+    echo "No Java Process Found on this Machine."
+    exit 1
+else
+    result=`$JPS_CMD -lmv | grep -v jps`
+    if [[ "$result" == "" ]]; then
+        ps aux | grep -E '^admin.*java.*' | grep -v grep | awk 'BEGIN{ORS=""}{print $2" ";for(j=NF;j>=12;j--){if(match($j, /^\-[a-zA-Z0-9]/)) {break;} } for(i=j+1;i<=NF;i++) {print $i" "} for(i=12;i<=j;i++) {print $i" "} print "\n" }'
+    else
+        echo "$result"
+    fi
+fi

--- a/bin/sandbox-packages.sh
+++ b/bin/sandbox-packages.sh
@@ -32,6 +32,7 @@ cp ../sandbox-core/target/sandbox-core-*-jar-with-dependencies.jar ${SANDBOX_TAR
     && cp sandbox-logback.xml ${SANDBOX_TARGET_DIR}/cfg/sandbox-logback.xml \
     && cp sandbox.properties ${SANDBOX_TARGET_DIR}/cfg/sandbox.properties \
     && cp sandbox.sh ${SANDBOX_TARGET_DIR}/bin/sandbox.sh \
+    && cp jps.sh ${SANDBOX_TARGET_DIR}/bin/jps.sh \
     && cp install-local.sh ${SANDBOX_TARGET_DIR}/install-local.sh
 
 # sandbox's version


### PR DESCRIPTION
Add a feture can choose a running jvm process if missing -p port param. 

sample is like that
``` 
$ ./sandbox.sh
Found existing java process, please choose one and hit RETURN.
* [1]: 9296 zookeeper.jar 
  [2]: 14728  -Xms128m -Xmx750m sample.jar
```