### PR TITLE
修复在JDK8下travis-ci运行失败的问题

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ cache:
   directories:
     - "$HOME/.m2/repository"
 
+jdk:
+  - openjdk8
+
 script:
-  - export JAVA_HOME=$HOME/openjdk8
-  - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk8 --target $JAVA_HOME
+  - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+  - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
   - mvn -PgithubCI -X clean cobertura:cobertura -Dmaven.test.skip=false
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jdk:
 script:
   - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-  - mvn -PgithubCI -X clean cobertura:cobertura -Dmaven.test.skip=false
+  - mvn -PgithubCI clean cobertura:cobertura -Dmaven.test.skip=false
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jdk:
 script:
   - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-  - mvn -PgithubCI clean cobertura:cobertura -Dmaven.test.skip=false
+  - mvn -Pdefault clean cobertura:cobertura -Dmaven.test.skip=false
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ![BANNER](https://github.com/alibaba/jvm-sandbox/wiki/img/BANNER.png)
 
+[![Build Status](https://travis-ci.org/alibaba/jvm-sandbox.svg?branch=master)](https://travis-ci.org/alibaba/jvm-sandbox)
+[![codecov](https://codecov.io/gh/alibaba/jvm-sandbox/branch/master/graph/badge.svg)](https://codecov.io/gh/alibaba/jvm-sandbox)
 ![license](https://img.shields.io/github/license/alibaba/arthas.svg)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/alibaba/jvm-sandbox.svg)](http://isitmaintained.com/project/alibaba/jvm-sandbox "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/alibaba/jvm-sandbox.svg)](http://isitmaintained.com/project/alibaba/jvm-sandbox "Percentage of issues still open")

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,6 @@
             </activation>
         </profile>
 
-        <!-- GITHUB-CI -->
-        <profile>
-            <id>githubCI</id>
-            <properties>
-                <tools-jar>${java.home}/lib/tools.jar</tools-jar>
-            </properties>
-        </profile>
-
     </profiles>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,29 @@
         <sandbox.version>1.2.2</sandbox.version>
     </properties>
 
+    <profiles>
+
+        <!-- 默认 -->
+        <profile>
+            <id>default</id>
+            <properties>
+                <tools-jar>${java.home}/../lib/tools.jar</tools-jar>
+            </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+
+        <!-- GITHUB-CI -->
+        <profile>
+            <id>githubCI</id>
+            <properties>
+                <tools-jar>${java.home}/lib/tools.jar</tools-jar>
+            </properties>
+        </profile>
+
+    </profiles>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -95,7 +118,6 @@
                 </executions>
             </plugin>
 
-            <!--
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
@@ -110,7 +132,6 @@
                     </formats>
                 </configuration>
             </plugin>
-            -->
 
         </plugins>
     </build>

--- a/sandbox-core/pom.xml
+++ b/sandbox-core/pom.xml
@@ -77,7 +77,7 @@
             <artifactId>tools</artifactId>
             <version>1.8</version>
             <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
+            <systemPath>${tools-jar}</systemPath>
         </dependency>
 
         <dependency>

--- a/sandbox-debug-module/pom.xml
+++ b/sandbox-debug-module/pom.xml
@@ -22,7 +22,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <!--
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
@@ -38,7 +37,6 @@
                     </execution>
                 </executions>
             </plugin>
-            -->
         </plugins>
     </build>
 

--- a/sandbox-module-starter/pom.xml
+++ b/sandbox-module-starter/pom.xml
@@ -32,7 +32,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
@@ -48,7 +47,6 @@
                     </execution>
                 </executions>
             </plugin>
-            -->
         </plugins>
     </build>
 


### PR DESCRIPTION
目前由于travis-ci本身的问题，导致程序无法在JDK8版本下正常编译运行。现修复内容如下：

- 采用Shell脚本指定JAVA_HOME
- 删除 Mvn命令的" -X" 可选项，防止DEBUG日志过多导致travis-ci异常终止

travis-ci运行成功示例如下：
https://travis-ci.com/airfer/jvm-sandbox