### PR TITLE
Develop for 20191212 to fix  #253

### DIFF
--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/EventListenerHandler.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/EventListenerHandler.java
@@ -209,7 +209,7 @@ public class EventListenerHandler implements SpyHandler {
                          * Fix https://github.com/alibaba/jvm-sandbox/issues/253
                          * 在BeforeEvent中触发THROWS_IMMEDIATELY不会被同级的handleOnThrows感知
                          * 但是在其他情况下，THROWS_IMMEDIATELY会被同级的handleOnThrows处理，导致栈错位（连续两次handleOnEnd），
-                         * 同时THROWS_IMMEDIATELY无法被上级调用handleOnThrows感知，这里通过包装为
+                         * 栈错位可能导致THROWS_IMMEDIATELY无法被上级调用handleOnThrows感知，或者影响其他依赖调用栈的操作，这里通过包装为
                          * ImmediatelyThrowException，在同级的handleOnThrows处理时，直接在入口处向上抛出真正异常。
                          */
                         throwable = new ImmediatelyThrowException(throwable);

--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/ImmediatelyThrowException.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/ImmediatelyThrowException.java
@@ -1,0 +1,18 @@
+package com.alibaba.jvm.sandbox.core.enhance.weaver;
+
+/**
+ * @author zhuangpeng
+ * @since 2020/1/2
+ */
+public class ImmediatelyThrowException extends Throwable{
+    // 需要被抛出的目标异常
+    private Throwable target;
+
+    public ImmediatelyThrowException(Throwable target){
+        this.target = target;
+    }
+
+    public Throwable getTarget(){
+        return this.target;
+    }
+}


### PR DESCRIPTION
1. 用ImmediatelyThrowException包装THROWS_IMMEDIATELY返回的原始Throwable
2. 处在相同调用层级的handleOnThrows 感知到THROWS_IMMEDIATELY异常且异常实例类型是ImmediatelyThrowException的时候，在EventListenerHandler.handleOnThrows入口阶段,取出原始Throwable，直接Throw
 fix #253 