### PR TITLE
Develop for 20200518 issue 267

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,6 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>2.7</version>
@@ -74,7 +69,6 @@
                 </configuration>
             </plugin>
 
-            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -88,7 +82,6 @@
                     </execution>
                 </executions>
             </plugin>
-            -->
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/EventListenerHandler.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/EventListenerHandler.java
@@ -437,6 +437,7 @@ public class EventListenerHandler implements SpyHandler {
         // 在守护区内产生的事件不需要响应
         if (SandboxProtector.instance.isInProtecting()) {
             logger.debug("listener={} is in protecting, ignore processing call-before-event", listenerId);
+            return;
         }
 
         final EventProcessor wrap = mappingOfEventProcessor.get(listenerId);
@@ -480,6 +481,7 @@ public class EventListenerHandler implements SpyHandler {
         // 在守护区内产生的事件不需要响应
         if (SandboxProtector.instance.isInProtecting()) {
             logger.debug("listener={} is in protecting, ignore processing call-return-event", listenerId);
+            return;
         }
 
         final EventProcessor wrap = mappingOfEventProcessor.get(listenerId);
@@ -517,6 +519,7 @@ public class EventListenerHandler implements SpyHandler {
         // 在守护区内产生的事件不需要响应
         if (SandboxProtector.instance.isInProtecting()) {
             logger.debug("listener={} is in protecting, ignore processing call-throws-event", listenerId);
+            return;
         }
 
         final EventProcessor wrap = mappingOfEventProcessor.get(listenerId);
@@ -554,6 +557,7 @@ public class EventListenerHandler implements SpyHandler {
         // 在守护区内产生的事件不需要响应
         if (SandboxProtector.instance.isInProtecting()) {
             logger.debug("listener={} is in protecting, ignore processing call-line-event", listenerId);
+            return;
         }
 
         final EventProcessor wrap = mappingOfEventProcessor.get(listenerId);

--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/AsmUtils.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/AsmUtils.java
@@ -16,8 +16,14 @@ import static com.alibaba.jvm.sandbox.core.util.SandboxStringUtils.toInternalCla
 public class AsmUtils {
 
     /**
+     * 获取两个类型的共同父类
      * just the same
      * {@code org.objectweb.asm.ClassWriter#getCommonSuperClass(String, String)}
+     *
+     * @param type1  类型1
+     * @param type2  类型2
+     * @param loader 所在ClassLoader
+     * @return 共同的父类
      */
     public static String getCommonSuperClass(String type1, String type2, ClassLoader loader) {
         return getCommonSuperClassImplByAsm(type1, type2, loader);
@@ -28,10 +34,10 @@ public class AsmUtils {
         InputStream inputStreamOfType1 = null, inputStreamOfType2 = null;
         try {
             //targetClassLoader 为null，说明是BootStrapClassLoader，不能显式引用，故使用系统类加载器间接引用
-            if(null == targetClassLoader){
+            if (null == targetClassLoader) {
                 targetClassLoader = ClassLoader.getSystemClassLoader();
             }
-            if(null == targetClassLoader){
+            if (null == targetClassLoader) {
                 return "java/lang/Object";
             }
             inputStreamOfType1 = targetClassLoader.getResourceAsStream(type1 + ".class");

--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxClassUtils.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxClassUtils.java
@@ -12,8 +12,8 @@ public class SandboxClassUtils {
      * 是否是SANDBOX家族所管理的类
      * <p>
      * SANDBOX家族所管理的类包括：
-     * <li>{@code com.alibaba.jvm.sandbox.}开头的类名</li>
-     * <li>被{@code com.alibaba.jvm.sandbox.}开头的ClassLoader所加载的类</li>
+     * 1. {@code com.alibaba.jvm.sandbox.}开头的类名
+     * 2. 被{@code com.alibaba.jvm.sandbox.}开头的ClassLoader所加载的类
      * </p>
      *
      * @param internalClassName 类资源名

--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxClassUtils.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxClassUtils.java
@@ -30,7 +30,8 @@ public class SandboxClassUtils {
 
         // 类被com.alibaba.jvm.sandbox开头的ClassLoader所加载
         if (null != loader
-                && isSandboxPrefix(loader.getClass().getName())) {
+                // fix issue #267
+                && isSandboxPrefix(normalizeClass(loader.getClass().getName()))) {
             return true;
         }
 
@@ -38,6 +39,28 @@ public class SandboxClassUtils {
 
     }
 
+    /**
+     * 标准化类名
+     * <p>
+     * 入参：com.alibaba.jvm.sandbox
+     * 返回：com/alibaba/jvm/sandbox
+     * </p>
+     *
+     * @param className 类名
+     * @return 标准化类名
+     */
+    private static String normalizeClass(String className) {
+        return className.replace(".", "/");
+    }
+
+    /**
+     * 是否是sandbox自身的类
+     * <p>
+     * 需要注意internalClassName的格式形如: com/alibaba/jvm/sandbox
+     *
+     * @param internalClassName 类资源名
+     * @return true / false
+     */
     private static boolean isSandboxPrefix(String internalClassName) {
         return internalClassName.startsWith(SANDBOX_FAMILY_CLASS_RES_PREFIX)
                 && !isQaTestPrefix(internalClassName);


### PR DESCRIPTION
解决由于inst.addTransformer 在c lassDataSource.findForReTransform(matcher);之前，引起的加载SandboxClassUtils类 抛出 ClassCircularityError