### PR TITLE
Develop for issue 267  fix #267，fix asm stack error 

### DIFF
--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/asm/EventWeaver.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/asm/EventWeaver.java
@@ -271,12 +271,6 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
                 }
             }
 
-            /**
-             * 加载异常
-             */
-            private void loadThrow() {
-                dup();
-            }
 
             @Override
             public void visitMaxs(int maxStack, int maxLocals) {
@@ -286,11 +280,14 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
                 codeLockForTracing.lock(new CodeLock.Block() {
                     @Override
                     public void code() {
-                        loadThrow();
+                        int index = newLocal(Type.getType(Throwable.class));
+                        storeLocal(index);
+                        loadLocal(index);
                         push(namespace);
                         push(listenerId);
                         invokeStatic(ASM_TYPE_SPY, ASM_METHOD_Spy$spyMethodOnThrows);
                         processControl();
+                        loadLocal(index);
                     }
                 });
 

--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/asm/EventWeaver.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/asm/EventWeaver.java
@@ -271,7 +271,6 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
                 }
             }
 
-
             @Override
             public void visitMaxs(int maxStack, int maxLocals) {
                 mark(endLabel);
@@ -280,7 +279,7 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
                 codeLockForTracing.lock(new CodeLock.Block() {
                     @Override
                     public void code() {
-                        int index = newLocal(Type.getType(Throwable.class));
+                        int index = newLocal(ASM_TYPE_THROWABLE);
                         storeLocal(index);
                         loadLocal(index);
                         push(namespace);

--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/asm/EventWeaver.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/enhance/weaver/asm/EventWeaver.java
@@ -144,6 +144,9 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
 
             private final Label beginLabel = new Label();
             private final Label endLabel = new Label();
+            private final Label startCatchBlock = new Label();
+            private final Label endCatchBlock = new Label();
+            private int newlocal = -1;
 
             // 用来标记一个方法是否已经进入
             // JVM中的构造函数非常特殊，super();this();是在构造函数方法体执行之外进行，如果在这个之前进行了任何的流程改变操作
@@ -274,23 +277,25 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
             @Override
             public void visitMaxs(int maxStack, int maxLocals) {
                 mark(endLabel);
-                visitTryCatchBlock(beginLabel, endLabel, mark(), ASM_TYPE_THROWABLE.getInternalName());
+                mv.visitLabel(startCatchBlock);
+                visitTryCatchBlock(beginLabel, endLabel, startCatchBlock, ASM_TYPE_THROWABLE.getInternalName());
 
                 codeLockForTracing.lock(new CodeLock.Block() {
                     @Override
                     public void code() {
-                        int index = newLocal(ASM_TYPE_THROWABLE);
-                        storeLocal(index);
-                        loadLocal(index);
+                        newlocal = newLocal(ASM_TYPE_THROWABLE);
+                        storeLocal(newlocal);
+                        loadLocal(newlocal);
                         push(namespace);
                         push(listenerId);
                         invokeStatic(ASM_TYPE_SPY, ASM_METHOD_Spy$spyMethodOnThrows);
                         processControl();
-                        loadLocal(index);
+                        loadLocal(newlocal);
                     }
                 });
 
                 throwException();
+                mv.visitLabel(endCatchBlock);
                 super.visitMaxs(maxStack, maxLocals);
             }
 
@@ -427,11 +432,14 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
                 asmTryCatchBlocks.add(new AsmTryCatchBlock(start, end, handler, type));
             }
 
+
+
             @Override
             public void visitEnd() {
                 for (AsmTryCatchBlock tcb : asmTryCatchBlocks) {
                     super.visitTryCatchBlock(tcb.start, tcb.end, tcb.handler, tcb.type);
                 }
+                super.visitLocalVariable("t",ASM_TYPE_THROWABLE.getDescriptor(),null,startCatchBlock,endCatchBlock,newlocal);
                 super.visitEnd();
             }
 

--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxReflectUtils.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxReflectUtils.java
@@ -47,21 +47,6 @@ public class SandboxReflectUtils {
         }
     }
 
-    public static void unCaughtInvokeVoidMethod(final Method method,
-        final Object target,
-        final Object... parameterArray) {
-        final boolean isAccessible = method.isAccessible();
-        try {
-            method.setAccessible(true);
-            method.invoke(target, parameterArray);
-        } catch (Throwable e) {
-            throw new UnCaughtException(e);
-        } finally {
-            method.setAccessible(isAccessible);
-        }
-    }
-
-
     public static Field unCaughtGetClassDeclaredJavaField(final Class<?> clazz,
                                                           final String name) {
         try {

--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxReflectUtils.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxReflectUtils.java
@@ -47,6 +47,21 @@ public class SandboxReflectUtils {
         }
     }
 
+    public static void unCaughtInvokeVoidMethod(final Method method,
+        final Object target,
+        final Object... parameterArray) {
+        final boolean isAccessible = method.isAccessible();
+        try {
+            method.setAccessible(true);
+            method.invoke(target, parameterArray);
+        } catch (Throwable e) {
+            throw new UnCaughtException(e);
+        } finally {
+            method.setAccessible(isAccessible);
+        }
+    }
+
+
     public static Field unCaughtGetClassDeclaredJavaField(final Class<?> clazz,
                                                           final String name) {
         try {

--- a/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/CalculatorImplByAdviceListenerTestCase.java
+++ b/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/CalculatorImplByAdviceListenerTestCase.java
@@ -4,6 +4,8 @@ import com.alibaba.jvm.sandbox.api.listener.ext.Advice;
 import com.alibaba.jvm.sandbox.qatest.core.enhance.listener.TracingAdviceListener;
 import com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator;
 import com.alibaba.jvm.sandbox.qatest.core.util.JvmHelper;
+import com.alibaba.jvm.sandbox.qatest.core.util.JvmHelper.ThirdTransformer;
+
 import org.junit.Test;
 
 import static com.alibaba.jvm.sandbox.api.ProcessController.returnImmediately;
@@ -973,6 +975,27 @@ public class CalculatorImplByAdviceListenerTestCase implements ICalculatorTestCa
                 "BEFORE|com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator.<init>(com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator$TestCase)|TRUE",
                 "RETURN|com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator.<init>(com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator$TestCase)|TRUE",
                 "AFTER|com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator.<init>(com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator$TestCase)|TRUE"
+        );
+    }
+
+    @Test
+    @Override
+    public void cal$report$multiEnhance() throws Throwable {
+        final TracingAdviceListener listener;
+        final Class<?> calculatorClass = JvmHelper
+            .createJvm()
+            .defineClass(
+                Calculator.class,
+                new JvmHelper.Transformer(
+                    CALCULATOR_REPORT_FILTER,
+                    listener = new TracingAdviceListener()
+                ),new ThirdTransformer(CALCULATOR_REPORT_FILTER,null)
+            ).loadClass(CALCULATOR_CLASS_NAME);
+        report(newInstance(calculatorClass), "test");
+        listener.assertTracing(
+            "BEFORE|com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator.report(java.lang.String)|TRUE",
+            "RETURN|com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator.report(java.lang.String)|TRUE",
+            "AFTER|com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator.report(java.lang.String)|TRUE"
         );
     }
 }

--- a/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/CalculatorImplByEventListenerTestCase.java
+++ b/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/CalculatorImplByEventListenerTestCase.java
@@ -3,9 +3,12 @@ package com.alibaba.jvm.sandbox.qatest.core.enhance;
 import com.alibaba.jvm.sandbox.api.event.BeforeEvent;
 import com.alibaba.jvm.sandbox.api.event.Event;
 import com.alibaba.jvm.sandbox.qatest.core.enhance.listener.LineNumTracingEventListener;
+import com.alibaba.jvm.sandbox.qatest.core.enhance.listener.TracingAdviceListener;
 import com.alibaba.jvm.sandbox.qatest.core.enhance.listener.TracingEventListener;
 import com.alibaba.jvm.sandbox.qatest.core.enhance.target.Calculator;
 import com.alibaba.jvm.sandbox.qatest.core.util.JvmHelper;
+import com.alibaba.jvm.sandbox.qatest.core.util.JvmHelper.ThirdTransformer;
+
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -970,6 +973,27 @@ public class CalculatorImplByEventListenerTestCase implements ICalculatorTestCas
         listener.assertEventTracing(
                 BEFORE,
                 RETURN
+        );
+    }
+
+    @Test
+    @Override
+    public void cal$report$multiEnhance() throws Throwable {
+        final TracingEventListener listener;
+        final Class<?> calculatorClass = JvmHelper
+            .createJvm()
+            .defineClass(
+                Calculator.class,
+                new JvmHelper.Transformer(
+                    CALCULATOR_REPORT_FILTER,
+                    listener = new TracingEventListener(),
+                    BEFORE, RETURN, THROWS
+                ),new JvmHelper.ThirdTransformer(CALCULATOR_REPORT_FILTER,null)
+            ).loadClass(CALCULATOR_CLASS_NAME);
+        report(newInstance(calculatorClass), "test");
+        listener.assertEventTracing(
+            BEFORE,
+            RETURN
         );
     }
 }

--- a/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/ICalculatorTestCase.java
+++ b/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/ICalculatorTestCase.java
@@ -1,5 +1,7 @@
 package com.alibaba.jvm.sandbox.qatest.core.enhance;
 
+import org.junit.Test;
+
 /**
  * Calculator类测试用例接口
  * <p>
@@ -269,4 +271,10 @@ public interface ICalculatorTestCase {
      */
     void cal$init_with_TestCase$before$changeParameters() throws Throwable;
 
+    /**
+     * {@code <init>(TestCase)}：调用跟踪 测试多次增强
+     *
+     * @throws Throwable 用例抛出异常
+     */
+    void cal$report$multiEnhance() throws Throwable;
 }

--- a/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/target/Calculator.java
+++ b/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/target/Calculator.java
@@ -147,7 +147,10 @@ public class Calculator {
         tCaseInStatic=tCase;
     }
 
-    public void report(String parma){
+    /**
+     * 空方法
+     */
+    public void report(String param){
 
     }
 

--- a/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/target/Calculator.java
+++ b/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/target/Calculator.java
@@ -147,4 +147,8 @@ public class Calculator {
         tCaseInStatic=tCase;
     }
 
+    public void report(String parma){
+
+    }
+
 }

--- a/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/transformer/TestThirdEnhance.java
+++ b/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/transformer/TestThirdEnhance.java
@@ -8,13 +8,13 @@ import com.alibaba.jvm.sandbox.core.enhance.weaver.asm.AsmMethods;
 import com.alibaba.jvm.sandbox.core.enhance.weaver.asm.AsmTypes;
 import com.alibaba.jvm.sandbox.core.util.AsmUtils;
 
-import jdk.internal.org.objectweb.asm.Type;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Method;
 
 import static com.alibaba.jvm.sandbox.core.util.SandboxStringUtils.toJavaClassName;

--- a/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/transformer/TestThirdEnhance.java
+++ b/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/transformer/TestThirdEnhance.java
@@ -1,0 +1,191 @@
+package com.alibaba.jvm.sandbox.qatest.core.enhance.transformer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+import com.alibaba.jvm.sandbox.core.enhance.weaver.asm.AsmMethods;
+import com.alibaba.jvm.sandbox.core.enhance.weaver.asm.AsmTypes;
+import com.alibaba.jvm.sandbox.core.util.AsmUtils;
+
+import jdk.internal.org.objectweb.asm.Type;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.commons.Method;
+
+import static com.alibaba.jvm.sandbox.core.util.SandboxStringUtils.toJavaClassName;
+import static org.apache.commons.io.FileUtils.writeByteArrayToFile;
+import static org.objectweb.asm.ClassReader.EXPAND_FRAMES;
+import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
+import static org.objectweb.asm.Opcodes.ASM7;
+
+/**
+ * 测试第三方transformer冲突情况
+ *
+ * @author zhuangpeng
+ * @since 2020/6/11
+ */
+public class TestThirdEnhance{
+
+    private static final boolean isDumpClass = true;
+
+    final Set<String/*BehaviorStructure#getSignCode()*/> signCodes;
+
+    public TestThirdEnhance(Set<String> signCodes) {this.signCodes = signCodes;}
+
+    public byte[] transform(ClassLoader loader, byte[] classfileBuffer){
+        // 返回增强后字节码
+        final ClassReader cr = new ClassReader(classfileBuffer);
+        final ClassWriter cw = createClassWriter(loader, cr);
+        cr.accept(new ThirdClassVisitor(ASM7,cw,signCodes,cr.getClassName()),
+            EXPAND_FRAMES
+        );
+        return dumpClassIfNecessary(cr.getClassName(), cw.toByteArray());
+    }
+
+    private byte[] dumpClassIfNecessary(String className, byte[] data) {
+        if (!isDumpClass) {
+            return data;
+        }
+        final File dumpClassFile = new File("./sandbox-class-dump/" + className + ".class");
+        final File classPath = new File(dumpClassFile.getParent());
+
+        // 创建类所在的包路径
+        if (!classPath.mkdirs()
+            && !classPath.exists()) {
+            return data;
+        }
+
+        // 将类字节码写入文件
+        try {
+            writeByteArrayToFile(dumpClassFile, data);
+        } catch (IOException e) {
+        }
+
+        return data;
+    }
+
+    private ClassWriter createClassWriter(final ClassLoader targetClassLoader,
+        final ClassReader cr) {
+        return new ClassWriter(cr, COMPUTE_FRAMES | COMPUTE_MAXS) {
+
+            /*
+             * 注意，为了自动计算帧的大小，有时必须计算两个类共同的父类。
+             * 缺省情况下，ClassWriter将会在getCommonSuperClass方法中计算这些，通过在加载这两个类进入虚拟机时，使用反射API来计算。
+             * 但是，如果你将要生成的几个类相互之间引用，这将会带来问题，因为引用的类可能还不存在。
+             * 在这种情况下，你可以重写getCommonSuperClass方法来解决这个问题。
+             *
+             * 通过重写 getCommonSuperClass() 方法，更正获取ClassLoader的方式，改成使用指定ClassLoader的方式进行。
+             * 规避了原有代码采用Object.class.getClassLoader()的方式
+             */
+            @Override
+            protected String getCommonSuperClass(String type1, String type2) {
+                return AsmUtils.getCommonSuperClass(type1, type2, targetClassLoader);
+            }
+
+        };
+    }
+
+
+   static Method method;
+
+    {
+        try {
+            method = Method.getMethod(Math.class.getDeclaredMethod("random"));
+        } catch (NoSuchMethodException e) {
+
+        }
+    }
+
+    public static class ThirdClassVisitor extends ClassVisitor {
+
+        private Set<String> signCodes;
+        private String targetJavaClassName;
+
+        public ThirdClassVisitor(int api,ClassVisitor cv, Set<String> signCodes,String targetClassInternalName) {
+            super(api,cv);
+            this.signCodes=signCodes;
+            this.targetJavaClassName = toJavaClassName(targetClassInternalName);
+        }
+
+        private String getBehaviorSignCode(final String name,
+            final String desc) {
+            final StringBuilder sb = new StringBuilder(256).append(targetJavaClassName).append("#").append(name).append("(");
+
+            final org.objectweb.asm.Type[] methodTypes = org.objectweb.asm.Type.getMethodType(desc).getArgumentTypes();
+            if (methodTypes.length != 0) {
+                sb.append(methodTypes[0].getClassName());
+                for (int i = 1; i < methodTypes.length; i++) {
+                    sb.append(",").append(methodTypes[i].getClassName());
+                }
+            }
+
+            return sb.append(")").toString();
+        }
+
+        private boolean isMatchedBehavior(final String signCode) {
+            return signCodes.contains(signCode);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(final int access, final String name, final String desc, final String signature,
+            final String[] exceptions) {
+            final MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+
+            final String signCode = getBehaviorSignCode(name, desc);
+            if (!isMatchedBehavior(signCode)) {
+                return mv;
+            }
+
+
+            return new ThirdReWriteMethod(api, mv) {
+                @Override
+                public void visitInsn(final int opcode) {
+                    switch (opcode) {
+                        case RETURN:
+                        case IRETURN:
+                        case FRETURN:
+                        case ARETURN:
+                        case LRETURN:
+                        case DRETURN:
+                            onExit();
+                            break;
+                        default:
+                            break;
+                    }
+                    super.visitInsn(opcode);
+                }
+
+                private void onExit() {
+                    Label startTryBlock = new Label();
+                    Label endTryBlock = new Label();
+                    Label startCatchBlock = new Label();
+                    Label endCatchBlock = new Label();
+                    mv.visitLabel(startTryBlock);
+                    //静态调用
+                    Type type = Type.getType(Math.class);
+                    String owner = type.getInternalName();
+                    mv.visitMethodInsn(INVOKESTATIC, owner, method.getName(), method.getDescriptor(), false);
+                    mv.visitInsn(POP2);
+                    mv.visitLabel(endTryBlock);
+                    mv.visitJumpInsn(GOTO,endCatchBlock);
+                    mv.visitLabel(startCatchBlock);
+                    mv.visitInsn(POP);
+                    mv.visitLabel(endCatchBlock);
+                    mv.visitTryCatchBlock(startTryBlock,endTryBlock,startCatchBlock,ASM_TYPE_THROWABLE.getInternalName());
+                }
+            };
+        }
+    }
+
+    public static class ThirdReWriteMethod extends MethodVisitor  implements Opcodes, AsmTypes, AsmMethods {
+        protected ThirdReWriteMethod(int api, MethodVisitor methodVisitor) {
+            super(api, methodVisitor);
+        }
+    }
+}

--- a/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/transformer/TestThirdEnhance.java
+++ b/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/enhance/transformer/TestThirdEnhance.java
@@ -25,14 +25,14 @@ import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 import static org.objectweb.asm.Opcodes.ASM7;
 
 /**
- * 测试第三方transformer冲突情况
+ * 测试第三方增强冲突情况
  *
  * @author zhuangpeng
  * @since 2020/6/11
  */
 public class TestThirdEnhance{
 
-    private static final boolean isDumpClass = true;
+    private static final boolean isDumpClass = false;
 
     final Set<String/*BehaviorStructure#getSignCode()*/> signCodes;
 

--- a/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/util/CalculatorHelper.java
+++ b/sandbox-core/src/test/java/com/alibaba/jvm/sandbox/qatest/core/util/CalculatorHelper.java
@@ -79,6 +79,15 @@ public class CalculatorHelper {
             "^sum$"
     );
 
+    /**
+     * 拦截report()方法过滤器
+     */
+    public static final Filter CALCULATOR_REPORT_FILTER
+        = new NameRegexFilter(
+        "^com\\.alibaba\\.jvm.sandbox\\.qatest\\.core\\.enhance\\.target\\.Calculator$",
+        "^report"
+    );
+
     public static final Filter CALCULATOR_INIT_FILTER_WITH_TEST_CASE
             = new Filter() {
         @Override
@@ -178,6 +187,31 @@ public class CalculatorHelper {
     }
 
     /**
+     * 调用report()方法
+     *
+     * @param calculatorObject 目标计算器对象实例
+     * @param strArray         参数
+     * @return 返回值
+     * @throws Throwable 调用失败
+     */
+    public static void report(final Object calculatorObject, String... strArray) throws Throwable {
+        try {
+             unCaughtInvokeMethod(
+                unCaughtGetClassDeclaredJavaMethod(calculatorObject.getClass(), "report", String.class),
+                calculatorObject,
+                strArray
+            );
+        } catch (Throwable cause) {
+            if (cause instanceof UnCaughtException
+                && (cause.getCause() instanceof InvocationTargetException)) {
+                throw ((InvocationTargetException) cause.getCause()).getTargetException();
+            }
+            throw cause;
+        }
+
+    }
+
+    /**
      * 调用addInStatic()方法
      *
      * @param calculatorObject addInStatic();
@@ -222,6 +256,8 @@ public class CalculatorHelper {
             return calculatorClass.getConstructor().newInstance();
         } catch (InvocationTargetException cause) {
             throw cause.getTargetException();
+        } catch (VerifyError e){
+            throw e;
         }
     }
 


### PR DESCRIPTION
解决由于inst.addTransformer 在classDataSource.findForReTransform(matcher);之前，引起的加载SandboxClassUtils类 抛出 ClassCircularityError