### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 9.4.41

### DIFF
--- a/sandbox-core/pom.xml
+++ b/sandbox-core/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.alibaba.jvm.sandbox</groupId>
@@ -133,7 +131,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>8.1.2.v20120308</version>
+            <version>9.4.41</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
### What happened？
There are 3 security vulnerabilities found in org.eclipse.jetty:jetty-server 8.1.2.v20120308
- [CVE-2021-34428](https://www.oscs1024.com/hd/CVE-2021-34428)
- [CVE-2019-10247](https://www.oscs1024.com/hd/CVE-2019-10247)
- [CVE-2017-7656](https://www.oscs1024.com/hd/CVE-2017-7656)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 8.1.2.v20120308 to 9.4.41 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS