### PR TITLE
fix(sec): upgrade ognl:ognl to 3.0.12

### DIFF
--- a/sandbox-debug-module/pom.xml
+++ b/sandbox-debug-module/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.alibaba.jvm.sandbox</groupId>
@@ -58,7 +56,7 @@
         <dependency>
             <groupId>ognl</groupId>
             <artifactId>ognl</artifactId>
-            <version>3.0.8</version>
+            <version>3.0.12</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ognl:ognl 3.0.8
- [CVE-2016-3093](https://www.oscs1024.com/hd/CVE-2016-3093)


### What did I do？
Upgrade ognl:ognl from 3.0.8 to 3.0.12 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS