### PR TITLE
修正脚本错误：SANDBOX_USER取uid

### DIFF
--- a/bin/sandbox.sh
+++ b/bin/sandbox.sh
@@ -11,7 +11,7 @@ typeset SANDBOX_HOME_DIR
 [[ -z ${SANDBOX_HOME_DIR} ]] && SANDBOX_HOME_DIR=${PWD}/..
 
 # define current SANDBOX_USER
-typeset SANDBOX_USER=${USER}
+typeset SANDBOX_USER=$(id -u)
 [[ -z ${SANDBOX_USER} ]] && SANDBOX_USER=$(whoami)
 
 # define sandbox's network


### PR DESCRIPTION
sanbox.sh 中 SANDBOX_USER 默认取值 USER变量（或whoami执行结果），

check_permission 中 pgrep -U "${SANDBOX_USER}"   需要传入参数为 uid
```shell 
pgrep [-U uid]
```

在macos 域环境下执行，check_permission()执行 pgrep找不到用户指定pid，永远无权限。
故SANDBOX_USER 取值改为 id -u