### PR TITLE
fix: replace printStackTrace with proper logging in LogbackUtils.destroy()

### DIFF
--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/LogbackUtils.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/LogbackUtils.java
@@ -1,4 +1,4 @@
-package com.alibaba.jvm.sandbox.core.util;
+﻿package com.alibaba.jvm.sandbox.core.util;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
@@ -50,10 +50,11 @@ public class LogbackUtils {
      * 销毁Logback日志框架
      */
     public static void destroy() {
+        final Logger logger = LoggerFactory.getLogger(LogbackUtils.class);
         try {
             ((LoggerContext) LoggerFactory.getILoggerFactory()).stop();
         } catch (Throwable cause) {
-            cause.printStackTrace();
+            logger.warn("destroy logback failed", cause);
         }
     }
 


### PR DESCRIPTION
# Pull Request: fix: replace printStackTrace with proper logging in LogbackUtils.destroy()

## Description
This PR fixes inconsistent error handling in `LogbackUtils.destroy()` by replacing `printStackTrace()` with proper SLF4J logging.

## Problem
The `destroy()` method in `LogbackUtils` uses `cause.printStackTrace()` to handle exceptions, which:
- Bypasses the logging framework (SLF4J/Logback)
- Outputs directly to System.err instead of configured log appenders
- Is inconsistent with the `init()` method in the same class, which properly uses `logger.warn()`

## Solution
Replace `printStackTrace()` with `logger.warn()` using SLF4J, making it consistent with the `init()` method in the same class.

## Changes
- Modified: `sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/LogbackUtils.java`
  - Added logger initialization in `destroy()` method
  - Replaced `cause.printStackTrace()` with `logger.warn("destroy logback failed", cause)`

## Impact
- Improves consistency within `LogbackUtils` class
- Ensures exceptions are properly logged through the configured logging framework
- Makes debugging easier in production environments
- No breaking changes to public API

## Testing
- Changes are minimal (1 file, +3/-2 lines) and low-risk
- Existing test suite should cover this code path
- Local environment limitations prevent full dynamic testing
- Final validation relies on CI/CD automated testing

## Related Issue
Fixes the issue: "Replace printStackTrace with proper logging in LogbackUtils"

## Note
This is a focused, single-issue fix addressing only the `destroy()` method's error handling. The change follows the same pattern already used in the `init()` method of the same class.
